### PR TITLE
#45 simplify parser code when dealing with string

### DIFF
--- a/src/lib/parsec/parser.js
+++ b/src/lib/parsec/parser.js
@@ -103,7 +103,7 @@ class Parser{
     chain(p) {
         var self = this;
 
-        return new Parser((input, index=0) => 
+        return new Parser((input, index=0) =>
             p.parse(stream.buffered(stream.ofParser(self, input)), index)
         );
     }
@@ -167,7 +167,7 @@ function bindAccepted(accept_a, f) {
                 accept_b.offset,
                 accept_a.consumed || accept_b.consumed
             ),
-        (reject_b) => 
+        (reject_b) =>
             response.reject(
                 accept_a.input.location(reject_b.offset),
                 accept_a.consumed || reject_b.consumed
@@ -177,7 +177,7 @@ function bindAccepted(accept_a, f) {
 
 // Parser 'a 'c -> ('a -> Parser 'b 'c) -> Parser 'b 'c
 function bind(self, f) {
-    return new Parser((input, index=0) => 
+    return new Parser((input, index=0) =>
         self.parse(input, index).fold(
             (accept_a) => bindAccepted(accept_a, f),
             (reject_a) => reject_a
@@ -190,7 +190,7 @@ function choice(self, f) {
     return new Parser((input, index=0) =>
         self.parse(input, index).fold(
             (accept) => accept,
-            (reject) => reject.consumed ? reject : f.parse(input, index)        
+            (reject) => reject.consumed ? reject : f.parse(input, index)
         )
     );
 }
@@ -339,15 +339,19 @@ function charNotIn(c) {
     return satisfy((v) => c.indexOf(v) === -1);
 }
 
+// int -> Parser (List 'a') a'
+function subStream(length) {
+    return any().occurrence(length);
+}
+
+// int -> Parser string char
+function subString(length) {
+    return subStream(length).map((s) => s.join(""));
+}
+
 // string -> Parser string char
 function string(s) {
-    return new Parser((input, index=0) => {
-        if (input.subStreamAt(s.split(''), index)) {
-            return response.accept(s, input, index + s.length, true);
-        } else {
-            return response.reject(input.location(index), false);
-        }
-    });
+    return doTry(subString(s.length).filter((r) => r === s));
 }
 
 // string -> Parser string char
@@ -423,6 +427,7 @@ export default {
     satisfy: satisfy,
     try: doTry,
     any: any(),
+    subStream: subStream,
     digit: digit(),
     lowerCase: lowerCase(),
     upperCase: upperCase(),
@@ -433,6 +438,7 @@ export default {
     char: char,
     charIn: charIn,
     charNotIn: charNotIn,
+    subString: subString,
     string: string,
     notString: notString,
     charLiteral: charLiteral(),

--- a/src/test/parsec/parser_extensions_test.js
+++ b/src/test/parsec/parser_extensions_test.js
@@ -664,6 +664,7 @@ export default {
         test.deepEqual(parsing.value, expected, 'should be equal');
         test.done();
     },
+
     "expect flattenDeep ( 2+2) to return []": function (test) {
         // Main difference with sequence, is that a sequence element could be an array
         test.expect(1);
@@ -682,5 +683,32 @@ export default {
         test.done();
     },
 
+    "export subStream(4) to return [h,e,l,l]": function (test) {
+        // Main difference with sequence, is that a sequence element could be an array
+        test.expect(1);
+        // tests here
+        const string = 'hello';
+        const expected = ['h','e','l','l'];
+
+        const parsing = parser.subStream(4)
+                .parse(stream.ofString(string), 0);
+
+        test.deepEqual(parsing.value, expected, 'should be equal');
+        test.done();
+    },
+
+    "export subString(4) to return hell": function (test) {
+        // Main difference with sequence, is that a sequence element could be an array
+        test.expect(1);
+        // tests here
+        const string = 'hello';
+        const expected = 'hell';
+
+        const parsing = parser.subString(4)
+            .parse(stream.ofString(string), 0);
+
+        test.deepEqual(parsing.value, expected, 'should be equal');
+        test.done();
+    }
 
 };


### PR DESCRIPTION
This modification is a solution simplification using foundations like `occurrence(...)` raised in #45 